### PR TITLE
related to the issue #5 reported by morinokami-san

### DIFF
--- a/roles/gitlab-runner/tasks/main.yml
+++ b/roles/gitlab-runner/tasks/main.yml
@@ -30,6 +30,7 @@
   yum:
     name: "{{ gitlab_runner_versioned_package_name | default(gitlab_runner_package_name) }}"
     state: present
+    disable_gpg_check: yes
   register: install_packages
   until: install_packages|success
   retries: 5


### PR DESCRIPTION
[こちら](https://github.com/infra-ci-book/gitlab-vagrant-ansible/issues/5)でmorinokamiさんが報告済みですが、下記画像の症状（Package gitlab-runner-10.5.0-1.x86_64.rpm is not signed）を抑制する設定を入れました。
![notsigned](https://user-images.githubusercontent.com/3634132/57159980-786f1500-6e22-11e9-91fb-843e92b7485d.png)
